### PR TITLE
ZEN-10435: Persist packages directory to workspace in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,13 +20,14 @@ jobs:
           root: .
           paths:
             - node_modules
+            - packages
   build:
     <<: *defaults
     steps:
       - checkout
       - attach_workspace:
           at: .
-      - run: npm install && npm run bootstrap && npm run build
+      - run: npm run build
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
-      - run: npm install && npm run bootstrap && npm run test:coverage
+      - run: npm run test:coverage
       - persist_to_workspace:
           root: .
           paths:


### PR DESCRIPTION
There seems to be no way of caching multiple node_modules directories using wildcards or variables in CircleCI.

So we're just gonna persist the whole `packages` directory with dependencies and links and everything in the `prepare` job, so downstream jobs don't have to `npm install && npm run bootstrap` every time.