### PR TITLE
QUICK-FIX: Hide dropdown labels by default

### DIFF
--- a/packages/multiselect/Multiselect.vue
+++ b/packages/multiselect/Multiselect.vue
@@ -8,6 +8,7 @@
     :option-height="35"
     :value="value"
     :allow-empty="allowEmpty"
+    :show-labels="false"
     v-bind="$attrs"
     v-on="$listeners"
   >


### PR DESCRIPTION
This should be the default. It wasn't unified in all the variations before the move.