### PR TITLE
ZEN-11000: Bump bootstrap-vue to latest stable version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2780,14 +2780,14 @@
 			"dev": true
 		},
 		"@nuxt/opencollective": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/@nuxt/opencollective/-/opencollective-0.2.2.tgz",
-			"integrity": "sha512-ie50SpS47L+0gLsW4yP23zI/PtjsDRglyozX2G09jeiUazC1AJlGPZo0JUs9iuCDUoIgsDEf66y7/bSfig0BpA==",
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/@nuxt/opencollective/-/opencollective-0.3.0.tgz",
+			"integrity": "sha512-Vf09BxCdj1iT2IRqVwX5snaY2WCTkvM0O4cWWSO1ThCFuc4if0Q/nNwAgCxRU0FeYHJ7DdyMUNSdswCLKlVqeg==",
 			"dev": true,
 			"requires": {
-				"chalk": "^2.4.1",
-				"consola": "^2.3.0",
-				"node-fetch": "^2.3.0"
+				"chalk": "^2.4.2",
+				"consola": "^2.10.1",
+				"node-fetch": "^2.6.0"
 			}
 		},
 		"@octokit/endpoint": {
@@ -3827,15 +3827,15 @@
 			"dev": true
 		},
 		"bootstrap-vue": {
-			"version": "2.0.0-rc.27",
-			"resolved": "https://registry.npmjs.org/bootstrap-vue/-/bootstrap-vue-2.0.0-rc.27.tgz",
-			"integrity": "sha512-gXdpt2IsKbmC3SU0bf/RgldWwgrXK7G47yslOtkk4OA1z6fOzb2orM2vU5L8NCNZQomYax9LapRucv+8PByfdA==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/bootstrap-vue/-/bootstrap-vue-2.0.2.tgz",
+			"integrity": "sha512-hbGJjc/om9JfVNUFK76dnh+YutlZdZlKbpWw6OE9gHTkmbwstP/KxxELpZZgK/4SYtdxUPt/6W1CvdaeT1bNvQ==",
 			"dev": true,
 			"requires": {
-				"@nuxt/opencollective": "^0.2.2",
-				"bootstrap": "^4.3.1",
+				"@nuxt/opencollective": "^0.3.0",
+				"bootstrap": ">=4.3.1 <5.0.0",
 				"popper.js": "^1.15.0",
-				"portal-vue": "^2.1.5",
+				"portal-vue": "^2.1.6",
 				"vue-functional-data-merge": "^3.1.0"
 			}
 		},
@@ -4501,9 +4501,9 @@
 			}
 		},
 		"consola": {
-			"version": "2.9.0",
-			"resolved": "https://registry.npmjs.org/consola/-/consola-2.9.0.tgz",
-			"integrity": "sha512-34Iue+LRcWbndFIfZc5boNizWlsrRjqIBJZTe591vImgbnq7nx2EzlrLtANj9TH2Fxm7puFJBJAOk5BhvZOddQ==",
+			"version": "2.10.1",
+			"resolved": "https://registry.npmjs.org/consola/-/consola-2.10.1.tgz",
+			"integrity": "sha512-4sxpH6SGFYLADfUip4vuY65f/gEogrzJoniVhNUYkJHtng0l8ZjnDCqxxrSVRHOHwKxsy8Vm5ONZh1wOR3/l/w==",
 			"dev": true
 		},
 		"console-control-strings": {
@@ -11008,9 +11008,9 @@
 			"dev": true
 		},
 		"portal-vue": {
-			"version": "2.1.5",
-			"resolved": "https://registry.npmjs.org/portal-vue/-/portal-vue-2.1.5.tgz",
-			"integrity": "sha512-vZmdMn0mOo7puvxoMQ5zju6S29aFD+9yygJxyWQtPaMXS9xunAeoYdnx6yzfL9J8HD8pMZYgSieEIbioAKhrSQ==",
+			"version": "2.1.6",
+			"resolved": "https://registry.npmjs.org/portal-vue/-/portal-vue-2.1.6.tgz",
+			"integrity": "sha512-lvCF85D4e8whd0nN32D8FqKwwkk7nYUI3Ku8UAEx4Z1reomu75dv5evRUTZNaj1EalxxWNXiNl0EHRq36fG8WA==",
 			"dev": true
 		},
 		"posix-character-classes": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
 		"@vue/test-utils": "^1.0.0-beta.29",
 		"babel-core": "^7.0.0-bridge.0",
 		"babel-jest": "^24.8.0",
-		"bootstrap-vue": "^2.0.0-rc.27",
+		"bootstrap-vue": "^2.0.2",
 		"bundlesize": "^0.18.0",
 		"coveralls": "^3.0.5",
 		"eslint": "^6.1.0",

--- a/packages/_storybook_/package-lock.json
+++ b/packages/_storybook_/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@reciprocity/storybook",
-  "version": "0.4.6",
+  "version": "0.4.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -963,13 +963,13 @@
       "dev": true
     },
     "@nuxt/opencollective": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@nuxt/opencollective/-/opencollective-0.2.2.tgz",
-      "integrity": "sha512-ie50SpS47L+0gLsW4yP23zI/PtjsDRglyozX2G09jeiUazC1AJlGPZo0JUs9iuCDUoIgsDEf66y7/bSfig0BpA==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@nuxt/opencollective/-/opencollective-0.3.0.tgz",
+      "integrity": "sha512-Vf09BxCdj1iT2IRqVwX5snaY2WCTkvM0O4cWWSO1ThCFuc4if0Q/nNwAgCxRU0FeYHJ7DdyMUNSdswCLKlVqeg==",
       "requires": {
-        "chalk": "^2.4.1",
-        "consola": "^2.3.0",
-        "node-fetch": "^2.3.0"
+        "chalk": "^2.4.2",
+        "consola": "^2.10.1",
+        "node-fetch": "^2.6.0"
       },
       "dependencies": {
         "node-fetch": {
@@ -992,23 +992,61 @@
         "warning": "^3.0.0"
       }
     },
-    "@reciprocity/multiselect": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@reciprocity/multiselect/-/multiselect-0.2.0.tgz",
-      "integrity": "sha512-QJT6ktBRPeEYx3Tz/C7+SdaIADF6ntPqkNBHwfvs2i+GsTIZSUImXUs6WskYtDLwOV78XWxZq3AvT0RRQfIlEw==",
+    "@reciprocity/bootstrap": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@reciprocity/bootstrap/-/bootstrap-0.6.0.tgz",
+      "integrity": "sha512-5kDn3r+xMBtDXFwKXXC+rPTyQnJBWT/cz25He2Ff65ABZmkYFPadgRIrEq4Nq/D004FoLCDDcMiKufHLzikxJg=="
+    },
+    "@reciprocity/button": {
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/@reciprocity/button/-/button-0.1.10.tgz",
+      "integrity": "sha512-zIyoEtP8vyCrTcF3LniVvAivOEGvh0EvQibLj3H2J52SBPnQ61ZBxjC9VCOb/PUv+vgTr8gS1Y2gNyR+yVJuDg=="
+    },
+    "@reciprocity/color-input": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@reciprocity/color-input/-/color-input-0.1.5.tgz",
+      "integrity": "sha512-ZpkBcnZAJYbFsSZmCwfJFXNwCacQ0Gs/PJmyN/bSaGeEQDQmpOuBCbCdQc69zN6J0wrcY0RjMI+rGJ6jU0NiBw==",
       "requires": {
-        "@reciprocity/bootstrap": "^0.5.0",
+        "@reciprocity/bootstrap": "^0.6.0",
+        "@simonwep/pickr": "^1.2.7"
+      }
+    },
+    "@reciprocity/day-selector": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@reciprocity/day-selector/-/day-selector-0.1.4.tgz",
+      "integrity": "sha512-Htm6QVksZfg+pQUSdEokU4IM+sfjAJ52PLo6vW6LG2b2AwoasOEf5jh9i1F9BNRacokMh1Iud+I7gEmsB56uOg==",
+      "requires": {
+        "@reciprocity/bootstrap": "^0.6.0",
+        "date-fns": "^1.30.1",
+        "lodash.capitalize": "^4.2.1",
+        "lodash.clonedeep": "^4.5.0",
+        "lodash.includes": "^4.3.0",
+        "lodash.without": "^4.4.0"
+      }
+    },
+    "@reciprocity/loading-spinner": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@reciprocity/loading-spinner/-/loading-spinner-0.1.5.tgz",
+      "integrity": "sha512-qvYuJntlPHK3+5YGEGX0v+WZYzIg5LF6cdTjTA7m5Oxwkf6X0zjQVyK29Ais8F5qrWOY6djNFTctxlq7pln+Zw==",
+      "requires": {
+        "@reciprocity/bootstrap": "^0.6.0"
+      }
+    },
+    "@reciprocity/multiselect": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@reciprocity/multiselect/-/multiselect-0.2.2.tgz",
+      "integrity": "sha512-qbqg6wBeHzqppv0aCxl/JJl0rA9CGqrwS+T/tNtfoGmHfsh0AeLWnDT+3IGXZzUVMvbCq6sDphynPPGHj21Y6Q==",
+      "requires": {
+        "@reciprocity/bootstrap": "^0.6.0",
         "bootstrap": "^4.3.1",
         "lodash.isobject": "^3.0.2",
         "vue-multiselect": "^2.1.6"
-      },
-      "dependencies": {
-        "@reciprocity/bootstrap": {
-          "version": "0.5.2",
-          "resolved": "https://registry.npmjs.org/@reciprocity/bootstrap/-/bootstrap-0.5.2.tgz",
-          "integrity": "sha512-ADrZCxH0DHyhvYodXmPNc2QL/P4g1zI9jOYXUFcnjjuiQBhwMj2vSx8FzV4XicZBxccYr7ZvGND+tiIkYLKl4w=="
-        }
       }
+    },
+    "@simonwep/pickr": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@simonwep/pickr/-/pickr-1.4.2.tgz",
+      "integrity": "sha512-+gL7EVZPr5tL/0px6nf2b9kKa8TBWS1ZhP5r0LsRh4Ptys9a9ZwMN21SE0vYI153l8LK4KOzsOYcCzERvjRTLw=="
     },
     "@storybook/addon-actions": {
       "version": "5.1.11",
@@ -2829,14 +2867,14 @@
       "integrity": "sha512-rXqOmH1VilAt2DyPzluTi2blhk17bO7ef+zLLPlWvG494pDxcM234pJ8wTc/6R40UWizAIIMgxjvxZg5kmsbag=="
     },
     "bootstrap-vue": {
-      "version": "2.0.0-rc.27",
-      "resolved": "https://registry.npmjs.org/bootstrap-vue/-/bootstrap-vue-2.0.0-rc.27.tgz",
-      "integrity": "sha512-gXdpt2IsKbmC3SU0bf/RgldWwgrXK7G47yslOtkk4OA1z6fOzb2orM2vU5L8NCNZQomYax9LapRucv+8PByfdA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bootstrap-vue/-/bootstrap-vue-2.0.2.tgz",
+      "integrity": "sha512-hbGJjc/om9JfVNUFK76dnh+YutlZdZlKbpWw6OE9gHTkmbwstP/KxxELpZZgK/4SYtdxUPt/6W1CvdaeT1bNvQ==",
       "requires": {
-        "@nuxt/opencollective": "^0.2.2",
-        "bootstrap": "^4.3.1",
+        "@nuxt/opencollective": "^0.3.0",
+        "bootstrap": ">=4.3.1 <5.0.0",
         "popper.js": "^1.15.0",
-        "portal-vue": "^2.1.5",
+        "portal-vue": "^2.1.6",
         "vue-functional-data-merge": "^3.1.0"
       }
     },
@@ -3532,9 +3570,9 @@
       }
     },
     "consola": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/consola/-/consola-2.9.0.tgz",
-      "integrity": "sha512-34Iue+LRcWbndFIfZc5boNizWlsrRjqIBJZTe591vImgbnq7nx2EzlrLtANj9TH2Fxm7puFJBJAOk5BhvZOddQ=="
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-2.10.1.tgz",
+      "integrity": "sha512-4sxpH6SGFYLADfUip4vuY65f/gEogrzJoniVhNUYkJHtng0l8ZjnDCqxxrSVRHOHwKxsy8Vm5ONZh1wOR3/l/w=="
     },
     "console-browserify": {
       "version": "1.1.0",
@@ -3852,6 +3890,11 @@
       "requires": {
         "assert-plus": "^1.0.0"
       }
+    },
+    "date-fns": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
+      "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw=="
     },
     "date-now": {
       "version": "0.1.4",
@@ -6909,11 +6952,26 @@
       "integrity": "sha512-rlrc3yU3+JNOpZ9zj5pQtxnx2THmvRykwL4Xlxoa8I9lHBlVbbyPhgyPMioxVZ4NqyxaVVtaJnzsyOidQIhyyQ==",
       "dev": true
     },
+    "lodash.capitalize": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/lodash.capitalize/-/lodash.capitalize-4.2.1.tgz",
+      "integrity": "sha1-+CbJtOKoUR2E46yinbBeGk87cqk="
+    },
+    "lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
+    },
     "lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
       "dev": true
+    },
+    "lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
     },
     "lodash.isobject": {
       "version": "3.0.2",
@@ -6949,6 +7007,11 @@
       "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
       "integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ=",
       "dev": true
+    },
+    "lodash.without": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.without/-/lodash.without-4.4.0.tgz",
+      "integrity": "sha1-PNRXSgC2e643OpS3SHcmQFB7eqw="
     },
     "loose-envify": {
       "version": "1.4.0",
@@ -8129,9 +8192,9 @@
       "integrity": "sha512-w010cY1oCUmI+9KwwlWki+r5jxKfTFDVoadl7MSrIujHU5MJ5OR6HTDj6Xo8aoR/QsA56x8jKjA59qGH4ELtrA=="
     },
     "portal-vue": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/portal-vue/-/portal-vue-2.1.5.tgz",
-      "integrity": "sha512-vZmdMn0mOo7puvxoMQ5zju6S29aFD+9yygJxyWQtPaMXS9xunAeoYdnx6yzfL9J8HD8pMZYgSieEIbioAKhrSQ=="
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/portal-vue/-/portal-vue-2.1.6.tgz",
+      "integrity": "sha512-lvCF85D4e8whd0nN32D8FqKwwkk7nYUI3Ku8UAEx4Z1reomu75dv5evRUTZNaj1EalxxWNXiNl0EHRq36fG8WA=="
     },
     "posix-character-classes": {
       "version": "0.1.1",

--- a/packages/_storybook_/package.json
+++ b/packages/_storybook_/package.json
@@ -19,7 +19,7 @@
     "@reciprocity/loading-spinner": "^0.1.5",
     "@reciprocity/multiselect": "^0.2.2",
     "bootstrap": "^4.3.1",
-    "bootstrap-vue": "^2.0.0-rc.27",
+    "bootstrap-vue": "^2.0.2",
     "vue": "^2.6.10"
   },
   "devDependencies": {

--- a/packages/button/Button.vue
+++ b/packages/button/Button.vue
@@ -8,7 +8,7 @@
 </template>
 
 <script>
-import BButton from "bootstrap-vue/es/components/button/button";
+import { BButton } from "bootstrap-vue";
 
 export default {
   name: "Button",

--- a/packages/color-input/ColorInput.vue
+++ b/packages/color-input/ColorInput.vue
@@ -15,7 +15,7 @@
 <script>
 import Vue from "vue";
 import Pickr from "@simonwep/pickr";
-import BFormInput from "bootstrap-vue/es/components/form-input/form-input";
+import { BFormInput } from "bootstrap-vue";
 
 import "@simonwep/pickr/dist/themes/classic.min.css";
 


### PR DESCRIPTION
I'm having issues in certain tests on ZenGRC and I think it might be related to this, so I'm bumping the version and fixing imports here first.