### PR TITLE
ZEN-11190: Send slack notification on publish

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,6 +111,13 @@ jobs:
       - attach_workspace:
           at: .
       - run: ./scripts/pr-comment.js "🔬 [Click here](https://reciprocity.github.io/zenlib/branches/$CIRCLE_BRANCH) to test your changes on Storybook"
+  slack-message:
+    <<: *defaults
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - run: ./scripts/slack-message.js "$(git log -1 --pretty=%B)"
 
 workflows:
   version: 2
@@ -164,4 +171,11 @@ workflows:
           filters:
             branches:
               ignore:
+                - master
+      - slack-message:
+          requires:
+              - publish
+          filters:
+            branches:
+              only:
                 - master

--- a/package-lock.json
+++ b/package-lock.json
@@ -12886,6 +12886,16 @@
 			"integrity": "sha512-ZcYcZcT69nSLAR2oLN2JwNmLkJEKGooFMCdvOkFrToUt/WfcRWqhIg4P4KwY4dmLbuyXIx4o4YmPsvMRJYJd/w==",
 			"dev": true
 		},
+		"slack-notify": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/slack-notify/-/slack-notify-0.1.7.tgz",
+			"integrity": "sha512-eDWa4JTy77xbuOM8fZHqBFcEh+xDlol6gttnFxKFwNS0iNayzQ2G1cgbyHXSmBhk/55vooX15ar6W9DnEhw6yQ==",
+			"dev": true,
+			"requires": {
+				"lodash": "^4.17.10",
+				"request": "^2.51.0"
+			}
+		},
 		"slash": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
 		"rollup-plugin-node-resolve": "^5.2.0",
 		"rollup-plugin-postcss": "^2.0.3",
 		"rollup-plugin-vue": "^5.0.1",
+		"slack-notify": "^0.1.7",
 		"tslib": "^1.10.0",
 		"typescript": "^3.5.3",
 		"vue": "^2.6.10",

--- a/scripts/slack-message.js
+++ b/scripts/slack-message.js
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+
+const { SLACK_WEBHOOK } = process.env;
+
+const slack = require("slack-notify")(SLACK_WEBHOOK);
+
+const COMMIT_MESSAGE = process.argv[2];
+const RELEASE_MESSAGE_SNIPPET =
+  "chore(release): [skip ci] updated package versions";
+
+if (COMMIT_MESSAGE.indexOf(RELEASE_MESSAGE_SNIPPET) !== -1) {
+  const packages = COMMIT_MESSAGE.split("\n").splice(2);
+  const message = `🚀 New packages versions published to NPM! \n\n ${packages.join(
+    "\n"
+  )}`;
+
+  slack.success(message);
+}


### PR DESCRIPTION
[JIRA Ticket](https://reciprocitylabs.atlassian.net/browse/ZEN-11190)

#### Description
Sends a slack notification to the #zenlib slack channel after new package versions have been published.