### PR TITLE
fix: add class to Multiselect to increase specificity

### DIFF
--- a/packages/multiselect/Multiselect.spec.js
+++ b/packages/multiselect/Multiselect.spec.js
@@ -182,16 +182,18 @@ describe("Multiselect.vue", () => {
   describe("renders validation classes", () => {
     it("renders classes depending on the valid prop", () => {
       const wrapper = shallowMount(Multiselect);
-      expect(wrapper.attributes("class")).toEqual("");
+      const multiselect = wrapper.find(VueMultiselect);
+
+      expect(multiselect.attributes("class")).toEqual("");
 
       wrapper.setProps({ valid: true });
-      expect(wrapper.attributes("class")).toEqual("is-valid");
+      expect(multiselect.attributes("class")).toEqual("is-valid");
 
       wrapper.setProps({ valid: true });
-      expect(wrapper.attributes("class")).toEqual("is-valid");
+      expect(multiselect.attributes("class")).toEqual("is-valid");
 
       wrapper.setProps({ valid: false });
-      expect(wrapper.attributes("class")).toEqual("is-invalid");
+      expect(multiselect.attributes("class")).toEqual("is-invalid");
     });
   });
 });

--- a/packages/multiselect/Multiselect.vue
+++ b/packages/multiselect/Multiselect.vue
@@ -1,62 +1,64 @@
 <template>
-  <vue-multiselect
-    :name="name"
-    :multiple="multiple"
-    :disabled="disabled"
-    :class="validationClass"
-    :options="options"
-    :option-height="35"
-    :value="value"
-    :allow-empty="allowEmpty"
-    :show-labels="false"
-    v-bind="$attrs"
-    v-on="$listeners"
-  >
-    <!--
-      TODO: clean up when this is merged:
-      https://github.com/vuejs/vue/pull/7765
-    -->
-    <template
-      v-for="(slot, slotName) in $scopedSlots"
-      :slot="slotName"
-      slot-scope="props"
+  <div class="multiselect-wrapper">
+    <vue-multiselect
+      :name="name"
+      :multiple="multiple"
+      :disabled="disabled"
+      :class="validationClass"
+      :options="options"
+      :option-height="35"
+      :value="value"
+      :allow-empty="allowEmpty"
+      :show-labels="false"
+      v-bind="$attrs"
+      v-on="$listeners"
     >
-      <slot v-bind="props" :name="slotName" />
-    </template>
-
-    <template v-slot:clear>
-      <!-- Render hidden select element for form posting -->
-      <select
-        v-if="renderSelectElement"
-        :multiple="multiple"
-        :name="name"
-        class="d-none"
+      <!--
+        TODO: clean up when this is merged:
+        https://github.com/vuejs/vue/pull/7765
+      -->
+      <template
+        v-for="(slot, slotName) in $scopedSlots"
+        :slot="slotName"
+        slot-scope="props"
       >
-        <option
-          v-for="option in valueArray"
-          :key="option ? option.value : null"
-          :value="option ? option.value : null"
-          selected
-          >{{ option ? option.label : null }}</option
+        <slot v-bind="props" :name="slotName" />
+      </template>
+
+      <template v-slot:clear>
+        <!-- Render hidden select element for form posting -->
+        <select
+          v-if="renderSelectElement"
+          :multiple="multiple"
+          :name="name"
+          class="d-none"
         >
-      </select>
+          <option
+            v-for="option in valueArray"
+            :key="option ? option.value : null"
+            :value="option ? option.value : null"
+            selected
+            >{{ option ? option.label : null }}</option
+          >
+        </select>
 
-      <div
-        v-show="isValueSet && allowEmpty && !disabled"
-        class="multiselect__clear-button"
-        @mousedown.prevent="clearSelectedValue"
-      >
-        ×
-      </div>
+        <div
+          v-show="isValueSet && allowEmpty && !disabled"
+          class="multiselect__clear-button"
+          @mousedown.prevent="clearSelectedValue"
+        >
+          ×
+        </div>
 
-      <!-- Add child clear slot so people can still extend the VueMultiselect slot -->
-      <slot name="clear"></slot>
-    </template>
+        <!-- Add child clear slot so people can still extend the VueMultiselect slot -->
+        <slot name="clear"></slot>
+      </template>
 
-    <template slot="afterList">
-      <slot name="afterList" />
-    </template>
-  </vue-multiselect>
+      <template slot="afterList">
+        <slot name="afterList" />
+      </template>
+    </vue-multiselect>
+  </div>
 </template>
 
 <script>
@@ -207,516 +209,519 @@ $vue-ms-spinner-color: $dark;
 
 $title-truncate-width: 50ch;
 
-// --------------------------------
-// Select field
-// --
+.multiselect-wrapper {
+  // --------------------------------
+  // Select field
+  // --
 
-fieldset[disabled] .multiselect {
-  pointer-events: none;
-}
-
-.multiselect,
-.multiselect__input,
-.multiselect__single {
-  font-family: inherit;
-  font-size: inherit;
-  touch-action: manipulation;
-}
-
-.multiselect {
-  box-sizing: content-box;
-  display: block;
-  position: relative;
-  width: 100%;
-  min-height: $vue-ms-min-height;
-  text-align: left;
-  color: $vue-ms-color;
-
-  * {
-    box-sizing: border-box;
+  fieldset[disabled] .multiselect {
+    pointer-events: none;
   }
-  &:focus {
+
+  .multiselect,
+  .multiselect__input,
+  .multiselect__single {
+    font-family: inherit;
+    font-size: inherit;
+    touch-action: manipulation;
+  }
+
+  .multiselect {
+    box-sizing: content-box;
+    display: block;
+    position: relative;
+    width: 100%;
+    min-height: $vue-ms-min-height;
+    text-align: left;
+    color: $vue-ms-color;
+
+    * {
+      box-sizing: border-box;
+    }
+    &:focus {
+      outline: none;
+    }
+    &:not(.multiselect--active) {
+      cursor: pointer;
+    }
+  }
+
+  .multiselect--disabled {
+    background: $vue-ms-disabled-bg;
+    pointer-events: none;
+    opacity: $vue-ms-disabled-opacity;
+
+    .multiselect__current,
+    .multiselect__select {
+      background: $vue-ms-disabled-bg;
+      color: $vue-ms-disabled-color;
+    }
+  }
+
+  .multiselect--active {
+    z-index: 50;
+    &:not(.multiselect--above) .multiselect__current,
+    &:not(.multiselect--above) .multiselect__input,
+    &:not(.multiselect--above) .multiselect__tags {
+      border-bottom-left-radius: 0;
+      border-bottom-right-radius: 0;
+    }
+
+    &.multiselect__select {
+      transform: rotateZ(180deg);
+    }
+  }
+
+  .multiselect--above.multiselect--active .multiselect__current,
+  .multiselect--above.multiselect--active .multiselect__input,
+  .multiselect--above.multiselect--active .multiselect__tags {
+    border-top-left-radius: 0;
+    border-top-right-radius: 0;
+  }
+
+  .multiselect__input,
+  .multiselect__single {
+    position: relative;
+    float: left;
+    min-height: $vue-ms-min-height / 2;
+    line-height: 1;
+    border: none;
+    border-radius: $vue-ms-border-radius;
+    background: inherit;
+    padding: 0 0 0 $vue-ms-padding-x;
+    width: 100%;
+    transition: border 0.1s ease;
+    box-sizing: border-box;
+    margin-bottom: $vue-ms-padding-y;
+    vertical-align: top;
+    overflow: hidden;
+    max-width: 100%;
+  }
+
+  .multiselect__input {
+    padding-left: 0;
+    margin-bottom: 6px;
+  }
+  .multiselect__input::placeholder {
+    color: $vue-ms-placeholder-color;
+  }
+
+  .multiselect__tag ~ .multiselect__input,
+  .multiselect__tag ~ .multiselect__single {
+    width: auto;
+  }
+
+  .multiselect__input:hover,
+  .multiselect__single:hover {
+    border-color: $color-ghost;
+  }
+
+  .multiselect__input:focus,
+  .multiselect__single:focus {
+    border-color: $color-hit-gray;
     outline: none;
   }
-  &:not(.multiselect--active) {
-    cursor: pointer;
-  }
-}
 
-.multiselect--disabled {
-  background: $vue-ms-disabled-bg;
-  pointer-events: none;
-  opacity: $vue-ms-disabled-opacity;
-
-  .multiselect__current,
-  .multiselect__select {
-    background: $vue-ms-disabled-bg;
-    color: $vue-ms-disabled-color;
-  }
-}
-
-.multiselect--active {
-  z-index: 50;
-  &:not(.multiselect--above) .multiselect__current,
-  &:not(.multiselect--above) .multiselect__input,
-  &:not(.multiselect--above) .multiselect__tags {
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
+  .multiselect__single {
+    padding: $vue-ms-padding-y 0;
   }
 
-  &.multiselect__select {
-    transform: rotateZ(180deg);
-  }
-}
-
-.multiselect--above.multiselect--active .multiselect__current,
-.multiselect--above.multiselect--active .multiselect__input,
-.multiselect--above.multiselect--active .multiselect__tags {
-  border-top-left-radius: 0;
-  border-top-right-radius: 0;
-}
-
-.multiselect__input,
-.multiselect__single {
-  position: relative;
-  float: left;
-  min-height: $vue-ms-min-height / 2;
-  line-height: 1;
-  border: none;
-  border-radius: $vue-ms-border-radius;
-  background: inherit;
-  padding: 0 0 0 $vue-ms-padding-x;
-  width: 100%;
-  transition: border 0.1s ease;
-  box-sizing: border-box;
-  margin-bottom: $vue-ms-padding-y;
-  vertical-align: top;
-  overflow: hidden;
-  max-width: 100%;
-}
-
-.multiselect__input {
-  padding-left: 0;
-  margin-bottom: 6px;
-}
-.multiselect__input::placeholder {
-  color: $vue-ms-placeholder-color;
-}
-
-.multiselect__tag ~ .multiselect__input,
-.multiselect__tag ~ .multiselect__single {
-  width: auto;
-}
-
-.multiselect__input:hover,
-.multiselect__single:hover {
-  border-color: $color-ghost;
-}
-
-.multiselect__input:focus,
-.multiselect__single:focus {
-  border-color: $color-hit-gray;
-  outline: none;
-}
-
-.multiselect__single {
-  padding: $vue-ms-padding-y 0;
-}
-
-.multiselect__tags-wrap {
-  display: inline;
-}
-
-.multiselect__tags {
-  min-height: $vue-ms-min-height;
-  display: block;
-  padding: $vue-ms-padding-y calc(1em + 1rem + 25px) 0 $vue-ms-padding-x;
-  border-radius: $vue-ms-border-radius;
-  border: $vue-ms-border-width solid $vue-ms-border-color;
-  background: $custom-select-bg;
-  font-family: inherit;
-  font-size: inherit;
-
-  &::after {
-    content: "";
-    display: table;
-    clear: both;
-  }
-}
-
-.multiselect__tag {
-  position: relative;
-  float: left;
-  padding: $vue-ms-tag-padding-y ($vue-ms-tag-icon-size + $vue-ms-tag-padding-x)
-    $vue-ms-tag-padding-y $vue-ms-tag-padding-x;
-  border-radius: $vue-ms-tag-border-radius;
-  margin: 0 $vue-ms-tag-padding-x $vue-ms-tag-padding-y 0;
-  color: $vue-ms-tag-color;
-  background: $vue-ms-tag-bg;
-  white-space: nowrap;
-  overflow: hidden;
-  max-width: 100%;
-  text-overflow: ellipsis;
-  font-size: 100%;
-  font-weight: $vue-ms-tag-font-weight;
-}
-
-.multiselect__tag span {
-  @include truncate($title-truncate-width);
-}
-
-.multiselect__tag-icon {
-  cursor: pointer;
-  margin-left: $vue-ms-tag-padding-y;
-  position: absolute;
-  right: 0;
-  top: 0;
-  bottom: 0;
-  font-style: initial;
-  width: $vue-ms-tag-icon-size;
-  text-align: center;
-  line-height: 1.275rem;
-  transition: all 0.2s ease;
-  font-size: 50%;
-  font-weight: $vue-ms-tag-font-weight;
-  border-top-left-radius: 0;
-  border-bottom-left-radius: 0;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-}
-
-.multiselect__tag-icon::after {
-  content: "×";
-  color: $vue-ms-tag-icon-color;
-  font-size: 343%;
-  font-weight: 500;
-}
-
-.multiselect__tag-icon:focus,
-.multiselect__tag-icon:hover {
-  background: $vue-ms-tag-icon-bg-hover;
-}
-
-.multiselect__tag-icon:focus::after,
-.multiselect__tag-icon:hover::after {
-  color: $vue-ms-tag-icon-color-hover;
-}
-
-.multiselect__current {
-  line-height: $vue-ms-min-height / 2;
-  min-height: $vue-ms-min-height;
-  box-sizing: border-box;
-  display: block;
-  overflow: hidden;
-  padding: 8px 30px 0 12px;
-  white-space: nowrap;
-  margin: 0;
-  text-decoration: none;
-  border-radius: $vue-ms-border-radius;
-  border: 1px solid $vue-ms-border-color;
-  cursor: pointer;
-}
-
-.multiselect__select {
-  line-height: $vue-ms-min-height / 2;
-  display: block;
-  position: absolute;
-  box-sizing: border-box;
-  width: $vue-ms-min-height;
-  height: $vue-ms-min-height;
-  right: 0;
-  top: 0;
-  padding: ($vue-ms-arrow-padding) $vue-ms-arrow-padding;
-  margin: 0;
-  text-decoration: none;
-  text-align: center;
-  cursor: pointer;
-  transition: transform 0.2s ease;
-}
-
-.multiselect__select::before {
-  position: relative;
-  right: 0;
-  top: 70%;
-  color: $vue-ms-arrow-color;
-  border-style: solid;
-  border-width: $vue-ms-arrow-size $vue-ms-arrow-size 0 $vue-ms-arrow-size;
-  border-color: $vue-ms-arrow-color transparent transparent transparent;
-  content: "";
-}
-
-.multiselect__placeholder {
-  color: $vue-ms-placeholder-color;
-  display: inline-block;
-  margin-bottom: 6px;
-  padding-top: $vue-ms-padding-y;
-  line-height: 1;
-}
-
-.multiselect--active .multiselect__placeholder {
-  display: none;
-}
-
-.multiselect__content-wrapper {
-  position: absolute;
-  display: block;
-  background: $vue-ms-bg;
-  width: auto;
-  min-width: 100%;
-  max-height: 240px;
-  overflow: auto;
-  border: $vue-ms-border-width solid $vue-ms-border-color;
-  margin-top: -1px;
-  border-bottom-left-radius: $vue-ms-border-radius;
-  border-bottom-right-radius: $vue-ms-border-radius;
-  z-index: 50;
-  -webkit-overflow-scrolling: touch;
-}
-
-.multiselect__content {
-  list-style: none;
-  display: inline-block;
-  padding: 0;
-  margin: 0;
-  min-width: 100%;
-  vertical-align: top;
-}
-
-.multiselect--above .multiselect__content-wrapper {
-  bottom: 100%;
-  border-radius: $vue-ms-border-radius $vue-ms-border-radius 0 0;
-  border-bottom: none;
-  border-top: $vue-ms-border-width solid $vue-ms-border-color;
-}
-
-.multiselect__content::-webkit-scrollbar {
-  display: none;
-}
-
-.multiselect__element {
-  display: block;
-}
-
-.multiselect__option {
-  display: block;
-  padding: $vue-ms-padding-y $vue-ms-padding-x;
-  min-height: 0;
-  line-height: 1.5rem;
-  text-decoration: none;
-  text-transform: none;
-  position: relative;
-  cursor: pointer;
-  white-space: normal;
-}
-
-.multiselect__option::after {
-  top: 0;
-  right: 0;
-  position: absolute;
-  line-height: $vue-ms-min-height;
-  padding-right: 12px;
-  padding-left: 20px;
-  font-family: inherit;
-  font-size: inherit;
-}
-
-.multiselect__option--highlight {
-  background: $vue-ms-option-highlight-bg;
-  outline: none;
-  color: $vue-ms-option-highlight-color;
-}
-
-.multiselect__option--highlight::after {
-  content: attr(data-select);
-  background: $vue-ms-option-highlight-bg;
-  color: $vue-ms-option-highlight-color;
-}
-
-.multiselect__option--selected {
-  background: $vue-ms-option-selected-bg;
-  color: $vue-ms-option-selected-color;
-  font-weight: normal;
-}
-
-.multiselect__option--selected::after {
-  content: attr(data-selected);
-  color: $color-white;
-}
-
-.multiselect__option--selected.multiselect__option--highlight {
-  background: $vue-ms-option-selected-highlight-bg;
-  color: $vue-ms-option-selected-highlight-color;
-}
-
-.multiselect__option--selected.multiselect__option--highlight::after {
-  background: $vue-ms-option-selected-highlight-bg;
-  content: attr(data-deselect);
-  color: $vue-ms-option-selected-highlight-color;
-}
-
-.multiselect__option--disabled {
-  background: $vue-ms-disabled-bg;
-  color: $vue-ms-disabled-color;
-  cursor: text;
-  pointer-events: none;
-}
-
-.multiselect__option--group {
-  background: $vue-ms-disabled-bg;
-  color: $vue-ms-disabled-color;
-
-  &.multiselect__option--highlight {
-    background: $vue-ms-disabled-color;
-    color: $vue-ms-disabled-bg;
-  }
-
-  &.multiselect__option--highlight::after {
-    background: $vue-ms-disabled-color;
-  }
-}
-
-.multiselect__option--disabled.multiselect__option--highlight {
-  background: $vue-ms-disabled-bg;
-}
-
-.multiselect__option--group-selected.multiselect__option--highlight {
-  background: $vue-ms-option-selected-highlight-bg;
-  color: $vue-ms-option-selected-highlight-color;
-}
-
-.multiselect__option--group-selected.multiselect__option--highlight::after {
-  background: $vue-ms-option-selected-highlight-bg;
-  content: attr(data-deselect);
-  color: $vue-ms-option-selected-highlight-color;
-}
-
-.multiselect-enter-active,
-.multiselect-leave-active {
-  transition: all 0.15s ease;
-}
-
-.multiselect-enter,
-.multiselect-leave-active {
-  opacity: 0;
-}
-
-.multiselect__strong {
-  margin-bottom: $vue-ms-padding-y;
-  line-height: $vue-ms-min-height / 2;
-  display: inline-block;
-  vertical-align: top;
-}
-
-.multiselect__clear-button {
-  position: absolute;
-  height: 100%;
-  right: 30px;
-  padding: 2px 0;
-  font-size: 1.3em;
-  z-index: 10;
-  cursor: pointer;
-}
-
-// --------------------------------
-// Spinner
-// --
-
-.multiselect__spinner {
-  position: absolute;
-  right: 0;
-  top: 0;
-  width: $vue-ms-min-height;
-  height: $vue-ms-min-height;
-  background: $vue-ms-disabled-bg;
-  display: block;
-
-  &::before,
-  &::after {
-    position: absolute;
-    content: "";
-    top: 50%;
-    left: 50%;
-    margin: $vue-ms-spinner-margin 0 0 $vue-ms-spinner-margin;
-    width: $vue-ms-spinner-size;
-    height: $vue-ms-spinner-size;
-    border-radius: 100%;
-    border: $vue-ms-spinner-thickness solid transparent;
-    border-top-color: $vue-ms-spinner-color;
-    box-shadow: 0 0 0 1px transparent;
-  }
-
-  &::before {
-    animation: spinning 2.4s cubic-bezier(0.41, 0.26, 0.2, 0.62);
-    animation-iteration-count: infinite;
-  }
-
-  &::after {
-    animation: spinning 2.4s cubic-bezier(0.51, 0.09, 0.21, 0.8);
-    animation-iteration-count: infinite;
-  }
-}
-
-@keyframes spinning {
-  from {
-    transform: rotate(0);
-  }
-
-  to {
-    transform: rotate(2turn);
-  }
-}
-
-// --------------------------------
-// Loading state
-// --
-
-.multiselect__loading-enter-active,
-.multiselect__loading-leave-active {
-  transition: opacity 0.4s ease-in-out;
-  opacity: 1;
-}
-
-.multiselect__loading-enter,
-.multiselect__loading-leave-active {
-  opacity: 0;
-}
-
-// --------------------------------
-// RTL adjustments
-// --
-
-*[dir="rtl"] {
-  .multiselect {
-    text-align: right;
-  }
-
-  .multiselect__select {
-    right: auto;
-    left: 1px;
+  .multiselect__tags-wrap {
+    display: inline;
   }
 
   .multiselect__tags {
-    padding: $vue-ms-padding-y $vue-ms-padding-y 0 $vue-ms-min-height;
+    min-height: $vue-ms-min-height;
+    display: block;
+    padding: $vue-ms-padding-y calc(1em + 1rem + 25px) 0 $vue-ms-padding-x;
+    border-radius: $vue-ms-border-radius;
+    border: $vue-ms-border-width solid $vue-ms-border-color;
+    background: $custom-select-bg;
+    font-family: inherit;
+    font-size: inherit;
+
+    &::after {
+      content: "";
+      display: table;
+      clear: both;
+    }
+  }
+
+  .multiselect__tag {
+    position: relative;
+    float: left;
+    padding: $vue-ms-tag-padding-y
+      ($vue-ms-tag-icon-size + $vue-ms-tag-padding-x) $vue-ms-tag-padding-y
+      $vue-ms-tag-padding-x;
+    border-radius: $vue-ms-tag-border-radius;
+    margin: 0 $vue-ms-tag-padding-x $vue-ms-tag-padding-y 0;
+    color: $vue-ms-tag-color;
+    background: $vue-ms-tag-bg;
+    white-space: nowrap;
+    overflow: hidden;
+    max-width: 100%;
+    text-overflow: ellipsis;
+    font-size: 100%;
+    font-weight: $vue-ms-tag-font-weight;
+  }
+
+  .multiselect__tag span {
+    @include truncate($title-truncate-width);
+  }
+
+  .multiselect__tag-icon {
+    cursor: pointer;
+    margin-left: $vue-ms-tag-padding-y;
+    position: absolute;
+    right: 0;
+    top: 0;
+    bottom: 0;
+    font-style: initial;
+    width: $vue-ms-tag-icon-size;
+    text-align: center;
+    line-height: 1.275rem;
+    transition: all 0.2s ease;
+    font-size: 50%;
+    font-weight: $vue-ms-tag-font-weight;
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+
+  .multiselect__tag-icon::after {
+    content: "×";
+    color: $vue-ms-tag-icon-color;
+    font-size: 343%;
+    font-weight: 500;
+  }
+
+  .multiselect__tag-icon:focus,
+  .multiselect__tag-icon:hover {
+    background: $vue-ms-tag-icon-bg-hover;
+  }
+
+  .multiselect__tag-icon:focus::after,
+  .multiselect__tag-icon:hover::after {
+    color: $vue-ms-tag-icon-color-hover;
+  }
+
+  .multiselect__current {
+    line-height: $vue-ms-min-height / 2;
+    min-height: $vue-ms-min-height;
+    box-sizing: border-box;
+    display: block;
+    overflow: hidden;
+    padding: 8px 30px 0 12px;
+    white-space: nowrap;
+    margin: 0;
+    text-decoration: none;
+    border-radius: $vue-ms-border-radius;
+    border: 1px solid $vue-ms-border-color;
+    cursor: pointer;
+  }
+
+  .multiselect__select {
+    line-height: $vue-ms-min-height / 2;
+    display: block;
+    position: absolute;
+    box-sizing: border-box;
+    width: $vue-ms-min-height;
+    height: $vue-ms-min-height;
+    right: 0;
+    top: 0;
+    padding: ($vue-ms-arrow-padding) $vue-ms-arrow-padding;
+    margin: 0;
+    text-decoration: none;
+    text-align: center;
+    cursor: pointer;
+    transition: transform 0.2s ease;
+  }
+
+  .multiselect__select::before {
+    position: relative;
+    right: 0;
+    top: 70%;
+    color: $vue-ms-arrow-color;
+    border-style: solid;
+    border-width: $vue-ms-arrow-size $vue-ms-arrow-size 0 $vue-ms-arrow-size;
+    border-color: $vue-ms-arrow-color transparent transparent transparent;
+    content: "";
+  }
+
+  .multiselect__placeholder {
+    color: $vue-ms-placeholder-color;
+    display: inline-block;
+    margin-bottom: 6px;
+    padding-top: $vue-ms-padding-y;
+    line-height: 1;
+  }
+
+  .multiselect--active .multiselect__placeholder {
+    display: none;
+  }
+
+  .multiselect__content-wrapper {
+    position: absolute;
+    display: block;
+    background: $vue-ms-bg;
+    width: auto;
+    min-width: 100%;
+    max-height: 240px;
+    overflow: auto;
+    border: $vue-ms-border-width solid $vue-ms-border-color;
+    margin-top: -1px;
+    border-bottom-left-radius: $vue-ms-border-radius;
+    border-bottom-right-radius: $vue-ms-border-radius;
+    z-index: 50;
+    -webkit-overflow-scrolling: touch;
   }
 
   .multiselect__content {
-    text-align: right;
+    list-style: none;
+    display: inline-block;
+    padding: 0;
+    margin: 0;
+    min-width: 100%;
+    vertical-align: top;
+  }
+
+  .multiselect--above .multiselect__content-wrapper {
+    bottom: 100%;
+    border-radius: $vue-ms-border-radius $vue-ms-border-radius 0 0;
+    border-bottom: none;
+    border-top: $vue-ms-border-width solid $vue-ms-border-color;
+  }
+
+  .multiselect__content::-webkit-scrollbar {
+    display: none;
+  }
+
+  .multiselect__element {
+    display: block;
+  }
+
+  .multiselect__option {
+    display: block;
+    padding: $vue-ms-padding-y $vue-ms-padding-x;
+    min-height: 0;
+    line-height: 1.5rem;
+    text-decoration: none;
+    text-transform: none;
+    position: relative;
+    cursor: pointer;
+    white-space: normal;
   }
 
   .multiselect__option::after {
-    right: auto;
-    left: 0;
+    top: 0;
+    right: 0;
+    position: absolute;
+    line-height: $vue-ms-min-height;
+    padding-right: 12px;
+    padding-left: 20px;
+    font-family: inherit;
+    font-size: inherit;
   }
 
-  .multiselect__clear {
-    right: auto;
-    left: 12px;
+  .multiselect__option--highlight {
+    background: $vue-ms-option-highlight-bg;
+    outline: none;
+    color: $vue-ms-option-highlight-color;
   }
+
+  .multiselect__option--highlight::after {
+    content: attr(data-select);
+    background: $vue-ms-option-highlight-bg;
+    color: $vue-ms-option-highlight-color;
+  }
+
+  .multiselect__option--selected {
+    background: $vue-ms-option-selected-bg;
+    color: $vue-ms-option-selected-color;
+    font-weight: normal;
+  }
+
+  .multiselect__option--selected::after {
+    content: attr(data-selected);
+    color: $color-white;
+  }
+
+  .multiselect__option--selected.multiselect__option--highlight {
+    background: $vue-ms-option-selected-highlight-bg;
+    color: $vue-ms-option-selected-highlight-color;
+  }
+
+  .multiselect__option--selected.multiselect__option--highlight::after {
+    background: $vue-ms-option-selected-highlight-bg;
+    content: attr(data-deselect);
+    color: $vue-ms-option-selected-highlight-color;
+  }
+
+  .multiselect__option--disabled {
+    background: $vue-ms-disabled-bg;
+    color: $vue-ms-disabled-color;
+    cursor: text;
+    pointer-events: none;
+  }
+
+  .multiselect__option--group {
+    background: $vue-ms-disabled-bg;
+    color: $vue-ms-disabled-color;
+
+    &.multiselect__option--highlight {
+      background: $vue-ms-disabled-color;
+      color: $vue-ms-disabled-bg;
+    }
+
+    &.multiselect__option--highlight::after {
+      background: $vue-ms-disabled-color;
+    }
+  }
+
+  .multiselect__option--disabled.multiselect__option--highlight {
+    background: $vue-ms-disabled-bg;
+  }
+
+  .multiselect__option--group-selected.multiselect__option--highlight {
+    background: $vue-ms-option-selected-highlight-bg;
+    color: $vue-ms-option-selected-highlight-color;
+  }
+
+  .multiselect__option--group-selected.multiselect__option--highlight::after {
+    background: $vue-ms-option-selected-highlight-bg;
+    content: attr(data-deselect);
+    color: $vue-ms-option-selected-highlight-color;
+  }
+
+  .multiselect-enter-active,
+  .multiselect-leave-active {
+    transition: all 0.15s ease;
+  }
+
+  .multiselect-enter,
+  .multiselect-leave-active {
+    opacity: 0;
+  }
+
+  .multiselect__strong {
+    margin-bottom: $vue-ms-padding-y;
+    line-height: $vue-ms-min-height / 2;
+    display: inline-block;
+    vertical-align: top;
+  }
+
+  .multiselect__clear-button {
+    position: absolute;
+    height: 100%;
+    right: 30px;
+    padding: 2px 0;
+    font-size: 1.3em;
+    z-index: 10;
+    cursor: pointer;
+  }
+
+  // --------------------------------
+  // Spinner
+  // --
 
   .multiselect__spinner {
-    right: auto;
-    left: 1px;
+    position: absolute;
+    right: 0;
+    top: 0;
+    width: $vue-ms-min-height;
+    height: $vue-ms-min-height;
+    background: $vue-ms-disabled-bg;
+    display: block;
+
+    &::before,
+    &::after {
+      position: absolute;
+      content: "";
+      top: 50%;
+      left: 50%;
+      margin: $vue-ms-spinner-margin 0 0 $vue-ms-spinner-margin;
+      width: $vue-ms-spinner-size;
+      height: $vue-ms-spinner-size;
+      border-radius: 100%;
+      border: $vue-ms-spinner-thickness solid transparent;
+      border-top-color: $vue-ms-spinner-color;
+      box-shadow: 0 0 0 1px transparent;
+    }
+
+    &::before {
+      animation: spinning 2.4s cubic-bezier(0.41, 0.26, 0.2, 0.62);
+      animation-iteration-count: infinite;
+    }
+
+    &::after {
+      animation: spinning 2.4s cubic-bezier(0.51, 0.09, 0.21, 0.8);
+      animation-iteration-count: infinite;
+    }
+  }
+
+  @keyframes spinning {
+    from {
+      transform: rotate(0);
+    }
+
+    to {
+      transform: rotate(2turn);
+    }
+  }
+
+  // --------------------------------
+  // Loading state
+  // --
+
+  .multiselect__loading-enter-active,
+  .multiselect__loading-leave-active {
+    transition: opacity 0.4s ease-in-out;
+    opacity: 1;
+  }
+
+  .multiselect__loading-enter,
+  .multiselect__loading-leave-active {
+    opacity: 0;
+  }
+
+  // --------------------------------
+  // RTL adjustments
+  // --
+
+  *[dir="rtl"] {
+    .multiselect {
+      text-align: right;
+    }
+
+    .multiselect__select {
+      right: auto;
+      left: 1px;
+    }
+
+    .multiselect__tags {
+      padding: $vue-ms-padding-y $vue-ms-padding-y 0 $vue-ms-min-height;
+    }
+
+    .multiselect__content {
+      text-align: right;
+    }
+
+    .multiselect__option::after {
+      right: auto;
+      left: 0;
+    }
+
+    .multiselect__clear {
+      right: auto;
+      left: 12px;
+    }
+
+    .multiselect__spinner {
+      right: auto;
+      left: 1px;
+    }
   }
 }
 </style>


### PR DESCRIPTION
This should be a temporary fix. A proper way to prevent styles from leaking is to use scoped CSS (https://reciprocitylabs.atlassian.net/browse/ZEN-12877).