### PR TITLE
[ZEN-14777] fix: avoid mutating a prop directly

### DIFF
--- a/packages/color-input/ColorInput.vue
+++ b/packages/color-input/ColorInput.vue
@@ -1,12 +1,11 @@
 <template>
   <div class="d-flex align-items-center">
     <b-form-input
-      v-model="value"
+      v-model="color"
       :required="required"
       pattern="#[0-9A-Fa-f]{6}"
-      @input="$emit('input', value)"
     />
-    <color-picker v-model="value" />
+    <color-picker v-model="color" />
   </div>
 </template>
 
@@ -28,6 +27,16 @@ export default {
     required: {
       type: Boolean,
       default: false
+    }
+  },
+  computed: {
+    color: {
+      get: function() {
+        return this.value;
+      },
+      set: function(value) {
+        this.$emit("input", value);
+      }
     }
   }
 };


### PR DESCRIPTION
[JIRA ticket](https://reciprocitylabs.atlassian.net/browse/ZEN-14777)

**Description**
Currently, if you run storybook locally and go to ColorInput example, if you change the color, you will see this console log error:

![image](https://user-images.githubusercontent.com/10661693/79584150-62df1380-80a4-11ea-8afc-71214883a1ba.png)

This PR added a computed setter to avoid mutating the prop directly.