### PR TITLE
ZEN-15527: App styles: Add global box shadow override

### DIFF
--- a/packages/_bootstrap_/scss/custom.scss
+++ b/packages/_bootstrap_/scss/custom.scss
@@ -84,6 +84,9 @@ $border-radius: 0.125rem;
 $border-radius-lg: $border-radius;
 $border-radius-sm: $border-radius;
 
+$box-shadow: 0 0.25rem 0.625rem 0 rgba(57, 83, 122, 0.1);
+
+
 // Tables
 $table-bg: $color-white;
 $table-border-width: 0;
@@ -125,6 +128,7 @@ $dropdown-item-padding-x: 1rem;
 $dropdown-link-hover-bg: $color-athens-gray;
 $dropdown-link-active-bg: $color-waikawa-gray;
 $dropdown-link-active-hover-bg: $color-east-bay;
+$dropdown-box-shadow: $box-shadow !default;
 
 // Pagination
 $pagination-padding-y: 0.25rem;
@@ -173,4 +177,3 @@ $alert-color-level: 2;
 $badge-font-size: 0.75rem;
 
 /* stylelint-enable color-no-hex */
-


### PR DESCRIPTION
[JIRA ticket](https://reciprocitylabs.atlassian.net/browse/ZEN-15527)

PR adds global override for Bootstrap's box shadow.

Example in designs: https://app.abstract.com/projects/9064f6f0-cbc2-11e8-8c39-a92298c1f63e/branches/e7f08fcd-168b-45c9-b88c-606fed238fac/commits/138ca44c8bd7b03819e98835d1d0f420f066b823/files/29883E6C-C2A1-412D-B2A3-CB5C497C0BC6/layers/226D3F8F-DE9A-46E0-87B9-AB441B810B15?collectionId=21a5c69e-ee62-4b40-8884-e39868000ffd&collectionLayerId=6d29e56f-d8a3-4a88-b529-2d73791acffd
