### PR TITLE
Fix: Disable multiselect item's checkbox

### DIFF
--- a/packages/multiselect/Multiselect.vue
+++ b/packages/multiselect/Multiselect.vue
@@ -786,6 +786,7 @@ $title-truncate-width: 50ch;
   }
 
   .checkbox_parent {
+    pointer-events: none;
     display: flex;
     align-items: center;
   }


### PR DESCRIPTION
Clicking the item does the same as clicking on item itself. So it's better to just prevent checkbox clicking, because it can have unwanted sidefects sometimes.