### PR TITLE
ZEN-16358: Dropdowns - Remove z-indexes from feature buttons

### DIFF
--- a/packages/multiselect/Multiselect.vue
+++ b/packages/multiselect/Multiselect.vue
@@ -692,7 +692,6 @@ $title-truncate-width: 50ch;
     text-align: center;
     cursor: pointer;
     transition: transform 0.2s ease;
-    z-index: 2;
   }
 
   .multiselect__select::before {
@@ -903,7 +902,6 @@ $title-truncate-width: 50ch;
     right: 30px;
     padding: 2px 0;
     font-size: 1.3em;
-    z-index: 10;
     cursor: pointer;
   }
 


### PR DESCRIPTION
It's better to not define z-indexes if we don't explicitly need them. Otherwise, we'll often bump into problems like the one mentioned in https://reciprocitylabs.atlassian.net/browse/ZEN-16358. Dropdown arrows are placed in front of the sticky bottom toolbar:
![Screenshot 2020-07-29 at 11 48 59](https://user-images.githubusercontent.com/5729421/88799759-3fe5f480-d1a7-11ea-8912-ba984da66688.jpg)

Since .multiselect__tags has a static position, we can safely remove this z-indexes on underlying feature buttons (dropdown arrow, clear all x button)