### PR TITLE
QUICKFIX: Revert mulitlsect z indexes

### DIFF
--- a/packages/multiselect/Multiselect.vue
+++ b/packages/multiselect/Multiselect.vue
@@ -692,6 +692,7 @@ $title-truncate-width: 50ch;
     text-align: center;
     cursor: pointer;
     transition: transform 0.2s ease;
+    z-index: 2;
   }
 
   .multiselect__select::before {
@@ -902,6 +903,7 @@ $title-truncate-width: 50ch;
     right: 30px;
     padding: 2px 0;
     font-size: 1.3em;
+    z-index: 10;
     cursor: pointer;
   }
 


### PR DESCRIPTION
Revert this PR, because it was causing troubles with hiding the clear button
https://github.com/reciprocity/zenlib/pull/87