### PR TITLE
ZEN-16138: Email dragged and dropped from Outlook is cut rather than copied meaning it disappears from the customer's inbox

### DIFF
--- a/packages/file-dropzone/FileDropzone.spec.js
+++ b/packages/file-dropzone/FileDropzone.spec.js
@@ -20,7 +20,12 @@ describe("FileDropzone.vue", () => {
 
     expect(vm.isOver).toBe(false);
 
-    labelEl.dispatchEvent(new Event("dragover"));
+    const dragoverEvent = new Event("dragover");
+    dragoverEvent.dataTransfer = {
+      files: ["file1"]
+    };
+
+    labelEl.dispatchEvent(dragoverEvent);
 
     expect(vm.isOver).toBe(true);
 

--- a/packages/file-dropzone/FileDropzone.vue
+++ b/packages/file-dropzone/FileDropzone.vue
@@ -79,7 +79,8 @@ export default {
 
       this.isOver = false;
     },
-    dragOver() {
+    dragOver(event) {
+      event.dataTransfer.dropEffect = "copy";
       this.isOver = true;
     },
     dragOut() {


### PR DESCRIPTION
To properly reproduce you will ned a windows machine with outlook.
Drag-dropping emails from outlook into any "file-dropzone" will result in the email being removed from your inbox.

![before](https://user-images.githubusercontent.com/32458554/97306130-54955f80-185e-11eb-94d4-ba8bf7d39056.gif)

![after](https://user-images.githubusercontent.com/32458554/97306140-56f7b980-185e-11eb-81db-f10e5defcb13.gif)
